### PR TITLE
catch markdown errors and add another chunk

### DIFF
--- a/libs/anaconda-assistant-conda/src/anaconda_assistant_conda/core.py
+++ b/libs/anaconda-assistant-conda/src/anaconda_assistant_conda/core.py
@@ -33,5 +33,8 @@ def stream_response(system_message: str, prompt: str, is_a_tty: bool = True) -> 
 
             for chunk in response:
                 full_text += chunk
-                md = Markdown(full_text)
+                try:
+                    md = Markdown(full_text, hyperlinks=False)
+                except Exception:
+                    continue
                 live.update(md, refresh=True)


### PR DESCRIPTION
Sometimes the text to be rendered in the stream ends with `[link](https://` which will cause rich Markdown to fail. Here any exception thrown by the markdown parser will be caught and tried again with next chunk in the stream added.

Also, hyperlink rendering is disabled meaning the full url will be printed to the terminal