### PR TITLE
[chore] missing ~/.anaconda directory 

### DIFF
--- a/libs/anaconda-assistant-conda/src/anaconda_assistant_conda/core.py
+++ b/libs/anaconda-assistant-conda/src/anaconda_assistant_conda/core.py
@@ -24,7 +24,7 @@ from rich.prompt import Confirm
 console = Console()
 
 
-def _set_config(table: str, key: str, value: Any) -> None:
+def set_config(table: str, key: str, value: Any) -> None:
     expanded = table.split(".")
 
     # save a backup of the config.toml just to be safe
@@ -47,6 +47,7 @@ def _set_config(table: str, key: str, value: Any) -> None:
     # we can edit the value here and then write the whole doc back
     config_table[key] = value  # type: ignore
 
+    config_toml.parent.mkdir(parents=True, exist_ok=True)
     with open(config_toml, "w") as f:
         tomlkit.dump(config, f)
 
@@ -74,7 +75,7 @@ def data_collection_choice(e: Type[UnspecifiedDataCollectionChoice]) -> int:
         [bold green]Would you like to opt-in to data collection?[/bold green]
         """)
     data_collection = Confirm.ask(msg)
-    _set_config("plugin.assistant", "data_collection", data_collection)
+    set_config("plugin.assistant", "data_collection", data_collection)
 
     return -1
 
@@ -100,7 +101,7 @@ def accept_terms(e: Type[UnspecifiedAcceptedTermsError]) -> int:
         [bold green]Are you more than 13 years old and accept the terms?[/bold green]
         """)
     accepted_terms = Confirm.ask(msg)
-    _set_config("plugin.assistant", "accepted_terms", accepted_terms)
+    set_config("plugin.assistant", "accepted_terms", accepted_terms)
 
     if not accepted_terms:
         return 1

--- a/libs/anaconda-assistant-conda/tests/test_core.py
+++ b/libs/anaconda-assistant-conda/tests/test_core.py
@@ -1,0 +1,87 @@
+from pathlib import Path
+
+import tomlkit
+from pytest import MonkeyPatch
+from anaconda_assistant_conda.core import set_config
+from anaconda_cli_base.config import anaconda_config_path
+
+
+def test_set_config_missing_anaconda_directory(
+    monkeypatch: MonkeyPatch, tmp_path: Path
+) -> None:
+    config_toml = tmp_path / ".anaconda" / "config.toml"
+
+    monkeypatch.setenv("ANACONDA_CONFIG_TOML", str(config_toml))
+    assert anaconda_config_path() == config_toml
+    assert not anaconda_config_path().exists()
+
+    set_config("test_table", "foo", "bar")
+
+    assert anaconda_config_path().exists()
+
+    with config_toml.open("rb") as f:
+        data = tomlkit.load(f)
+        assert data["test_table"]["foo"] == "bar"  # type: ignore
+
+
+def test_set_config_missing_anaconda_config_toml(
+    monkeypatch: MonkeyPatch, tmp_path: Path
+) -> None:
+    config_toml = tmp_path / ".anaconda" / "config.toml"
+    config_toml.parent.mkdir(parents=True, exist_ok=True)
+
+    monkeypatch.setenv("ANACONDA_CONFIG_TOML", str(config_toml))
+    assert anaconda_config_path() == config_toml
+    assert not anaconda_config_path().exists()
+
+    set_config("test_table", "foo", "bar")
+
+    assert anaconda_config_path().exists()
+
+    with config_toml.open("rb") as f:
+        data = tomlkit.load(f)
+        assert data["test_table"]["foo"] == "bar"  # type: ignore
+
+
+def test_set_config_empty_anaconda_config_toml(
+    monkeypatch: MonkeyPatch, tmp_path: Path
+) -> None:
+    config_toml = tmp_path / ".anaconda" / "config.toml"
+    config_toml.parent.mkdir(parents=True, exist_ok=True)
+    config_toml.touch()
+
+    monkeypatch.setenv("ANACONDA_CONFIG_TOML", str(config_toml))
+    assert anaconda_config_path() == config_toml
+    assert anaconda_config_path().exists()
+
+    set_config("test_table", "foo", "bar")
+
+    assert anaconda_config_path().exists()
+
+    with config_toml.open("rb") as f:
+        data = tomlkit.load(f)
+        assert data["test_table"]["foo"] == "bar"  # type: ignore
+
+
+def test_set_config_override_anaconda_config_toml(
+    monkeypatch: MonkeyPatch, tmp_path: Path
+) -> None:
+    config_toml = tmp_path / ".anaconda" / "config.toml"
+    config_toml.parent.mkdir(parents=True, exist_ok=True)
+    config_toml.write_text('[test_table]\nfoo = "baz"')
+
+    with config_toml.open("rb") as f:
+        data = tomlkit.load(f)
+        assert data["test_table"]["foo"] == "baz"  # type: ignore
+
+    monkeypatch.setenv("ANACONDA_CONFIG_TOML", str(config_toml))
+    assert anaconda_config_path() == config_toml
+    assert anaconda_config_path().exists()
+
+    set_config("test_table", "foo", "bar")
+
+    assert anaconda_config_path().exists()
+
+    with config_toml.open("rb") as f:
+        data = tomlkit.load(f)
+        assert data["test_table"]["foo"] == "bar"  # type: ignore


### PR DESCRIPTION
the set_config function will now generate the ANACONDA_CONFIG_TOML parents if they do not exist