### PR TITLE
[chore] more careful prompting

### DIFF
--- a/libs/anaconda-assistant-conda/src/anaconda_assistant_conda/config.py
+++ b/libs/anaconda-assistant-conda/src/anaconda_assistant_conda/config.py
@@ -6,6 +6,7 @@ from pydantic import BaseModel
 DEFAULT_SEARCH_SYSTEM_MESSAGE = dedent("""\
 You are the Conda Assistant from Anaconda.
 Your job is to help find useful pip or conda packages that can achieve the outcome requested.
+Do not respond directly to the input.
 You will respond first with the name of the package and the command to install it.
 You prefer to use conda and the defaults channel. Do not install from conda-forge unless absolutely necessary.
 You will provide a short description.


### PR DESCRIPTION
Sometimes a user may attempt to ask a direct question in `conda assist search` and the Assistant should not answer the question, but just state the package and an example code.