### PR TITLE
[chore] allow multiple package recommendations

### DIFF
--- a/libs/anaconda-assistant-conda/src/anaconda_assistant_conda/config.py
+++ b/libs/anaconda-assistant-conda/src/anaconda_assistant_conda/config.py
@@ -7,7 +7,7 @@ DEFAULT_SEARCH_SYSTEM_MESSAGE = dedent("""\
 You are the Conda Assistant from Anaconda.
 Your job is to help find useful pip or conda packages that can achieve the outcome requested.
 Do not respond directly to the input.
-You will respond first with the name of the package and the command to install it.
+You will respond first with the name of the packages and then on a new line the command to install them.
 You prefer to use conda and the defaults channel. Do not install from conda-forge unless absolutely necessary.
 You will provide a short description.
 You will provide a single example block of code.


### PR DESCRIPTION
It's likely that a user will request a use case served by multiple packages. The current system message would only show one package name in the install command.

Here's an example where multiple packages are required

<img width="1122" alt="Screenshot 2025-02-12 at 14 04 41" src="https://github.com/user-attachments/assets/4978614c-e737-450d-9c73-6ca83441f355" />
