### PR TITLE
[chore] assume utf-8 encoding

### DIFF
--- a/libs/anaconda-assistant-sdk/src/anaconda_assistant/core.py
+++ b/libs/anaconda-assistant-sdk/src/anaconda_assistant/core.py
@@ -194,6 +194,7 @@ class ChatClient:
             }
 
         response = self.api_client.post("/completions", json=body, stream=True)
+        response.encoding = "utf-8"
         try:
             response.raise_for_status()
         except HTTPError as e:


### PR DESCRIPTION
I think the API does not set the encoding in the headers and requests has assumed ISO-8859-1. From experimentation it seems like UTF-8 is more accurate.