### PR TITLE
[chore] domain change

### DIFF
--- a/libs/anaconda-assistant-sdk/README.md
+++ b/libs/anaconda-assistant-sdk/README.md
@@ -99,7 +99,7 @@ while streaming.
 
 ## Daily quotas
 
-Each Anaconda.cloud subscription plan enforces a limit on the number of requests (calls to `.completions()`). The
+Each Anaconda subscription plan enforces a limit on the number of requests (calls to `.completions()`). The
 limits are documented on the [Plans and Pricing page](https://www.anaconda.com/pricing). Once the limit is reached
 the `.completions()` function will throw a `DailyQuotaExceeded` exception.
 

--- a/libs/anaconda-assistant-sdk/README.md
+++ b/libs/anaconda-assistant-sdk/README.md
@@ -152,10 +152,10 @@ print(prompted.complete('what is pi?'))
 
 A [LangChain integration](https://python.langchain.com/docs/introduction/) is provided that supports message streaming and non-streaming responses.
 
-Required packages: `langchain-core >=0.3`
+Required packages: `langchain-core >=0.3` and `langchain >=0.3`
 
 ```python
-from anaconda_assistant.langchain import AnacondaAssistant
+from anaconda_assistant.integrations.langchain import AnacondaAssistant
 from langchain.prompts import ChatPromptTemplate
 
 model = AnacondaAssistant()
@@ -170,7 +170,7 @@ print(message.content)
 
 You can use Anaconda Assistant as a model in the [ell](https://github.com/MadcowD/ell) prompt engineering framework.
 
-Required packages: `ell-ai`
+Required packages: `ell-ai[sqlite]` or `ell-ai[postgres]`
 
 ```python
 import ell
@@ -192,7 +192,7 @@ To use Anaconda Assistant with [PandasAI](https://github.com/Sinaptik-AI/pandas-
 Required packages: `pandasai`
 
 ```python
-from anaconda_assistant.pandasai import AnacondaAssistant
+from anaconda_assistant.integrations.pandasai import AnacondaAssistant
 from pandasai import SmartDataframe
 
 ai = AnacondaAssistant()
@@ -209,16 +209,17 @@ Required packages: `panel`
 ```python
 import panel as pn
 
-from anaconda_assistant import ChatSession
+from anaconda_auth import BaseClient
 from anaconda_assistant.integrations.panel import AnacondaAssistantCallbackHandler
 
-assistant = ChatSession()
-callback = AnacondaAssistantCallbackHandler(assistant)
+callback = AnacondaAssistantCallbackHandler()
+auth_client = BaseClient()
 
 chat = pn.chat.ChatInterface(
     callback=callback,
-    user=assistant.auth_client.name,
-    avatar=assistant.auth_client.avatar,
+    user=auth_client.name,
+    avatar=auth_client.avatar,
+    placeholder_threshold=0.05
 )
 ```
 

--- a/libs/anaconda-assistant-sdk/pyproject.toml
+++ b/libs/anaconda-assistant-sdk/pyproject.toml
@@ -44,7 +44,7 @@ pandasai = [
   "pandasai>=2.4"
 ]
 panel = [
-  "panel"
+  "panel >=1.6"
 ]
 publish = [
   "build",

--- a/libs/anaconda-assistant-sdk/src/anaconda_assistant/api_client.py
+++ b/libs/anaconda-assistant-sdk/src/anaconda_assistant/api_client.py
@@ -12,29 +12,20 @@ class APIClient(BaseClient):
     def __init__(
         self,
         domain: Optional[str] = None,
-        auth_domain: Optional[str] = None,
         api_key: Optional[str] = None,
-        user_agent: Optional[str] = None,
         api_version: Optional[str] = None,
         client_source: Optional[str] = None,
         ssl_verify: Optional[bool] = None,
         extra_headers: Optional[Union[str, dict]] = None,
     ):
         super().__init__(
-            domain=auth_domain,
+            domain=domain,
             api_key=api_key,
-            user_agent=user_agent,
             ssl_verify=ssl_verify,
             extra_headers=extra_headers,
         )
 
         kwargs: Dict[str, Any] = {}
-        if domain is not None:
-            kwargs["domain"] = domain
-        if ssl_verify is not None:
-            kwargs["ssl_verify"] = ssl_verify
-        if extra_headers is not None:
-            kwargs["extra_headers"] = extra_headers
         if api_version is not None:
             kwargs["api_version"] = api_version
         if client_source is not None:
@@ -43,15 +34,11 @@ class APIClient(BaseClient):
         self._config = AssistantConfig(**kwargs)
 
         self.headers["X-Client-Source"] = self._config.client_source
-        self.headers["X-Client-Version"] = self._config.api_version
-
-        self._base_uri = f"https://{self._config.domain}"
+        self.headers["X-Client-Version"] = version
 
     def urljoin(self, url: str) -> str:
         if url.startswith("http"):
             return url
 
-        joined = (
-            f"{self._base_uri.strip('/')}/{self._config.api_version}/{url.lstrip('/')}"
-        )
+        joined = f"{self._base_uri.strip('/')}/api/assistant/{self._config.api_version}/{url.lstrip('/')}"
         return joined

--- a/libs/anaconda-assistant-sdk/src/anaconda_assistant/config.py
+++ b/libs/anaconda-assistant-sdk/src/anaconda_assistant/config.py
@@ -3,7 +3,6 @@ from anaconda_cli_base.config import AnacondaBaseSettings
 
 
 class AssistantConfig(AnacondaBaseSettings, plugin_name="assistant"):
-    domain: str = "assistant.anaconda.cloud"
     client_source: str = "anaconda-cli-prod"
     api_version: str = "v3"
     accepted_terms: Optional[bool] = None

--- a/libs/anaconda-assistant-sdk/src/anaconda_assistant/core.py
+++ b/libs/anaconda-assistant-sdk/src/anaconda_assistant/core.py
@@ -198,8 +198,11 @@ class ChatClient:
         try:
             response.raise_for_status()
         except HTTPError as e:
-            msg = response.json().get("message")
-            if msg is None:
+            try:
+                msg = response.json().get("message")
+                if msg is None:
+                    msg = response.text
+            except json.JSONDecodeError:
                 msg = response.text
             e.args = (f"{e.args[0]}. {msg}",)
 

--- a/libs/anaconda-assistant-sdk/src/anaconda_assistant/core.py
+++ b/libs/anaconda-assistant-sdk/src/anaconda_assistant/core.py
@@ -203,7 +203,7 @@ class ChatClient:
                 if msg is None:
                     msg = response.text
             except json.JSONDecodeError:
-                msg = response.text
+                msg = response.reason
             e.args = (f"{e.args[0]}. {msg}",)
 
             if e.response.status_code == 429:

--- a/libs/anaconda-assistant-sdk/src/anaconda_assistant/integrations/panel.py
+++ b/libs/anaconda-assistant-sdk/src/anaconda_assistant/integrations/panel.py
@@ -1,6 +1,7 @@
 import os
-from typing import Any
-from typing import Generator
+from asyncio import sleep
+from typing import Any, Optional
+from typing import AsyncGenerator
 
 from anaconda_assistant.core import ChatSession
 
@@ -8,17 +9,18 @@ HERE = os.path.dirname(__file__)
 
 
 class AnacondaAssistantCallbackHandler:
-    def __init__(
-        self,
-        session: ChatSession,
-    ) -> None:
-        self.session = session
+    def __init__(self, session: Optional[ChatSession] = None) -> None:
+        if session is None:
+            self.session = ChatSession()
+        else:
+            self.session = session
         self.assistant_avatar = os.path.join(HERE, "Anaconda_Logo.png")
         self.assistant_name = "Anaconda Assistant"
 
-    def __call__(self, content: str, *_: Any) -> Generator[Any, None, None]:
+    async def __call__(self, contents: str, *_: Any) -> AsyncGenerator[dict, None]:
+        await sleep(0.1)
         full_text = ""
-        for chunk in self.session.chat(content, stream=True):
+        for chunk in self.session.chat(contents, stream=True):
             full_text += chunk
             yield {
                 "user": self.assistant_name,

--- a/libs/anaconda-assistant-sdk/tests/test_core.py
+++ b/libs/anaconda-assistant-sdk/tests/test_core.py
@@ -184,7 +184,7 @@ def test_chat_client_system_message(mocked_api_client: APIClient) -> None:
     system_message = "You are a kitty"
 
     client = ChatClient(
-        system_message=system_message, domain=mocked_api_client._config.domain
+        system_message=system_message, domain=mocked_api_client.config.domain
     )
 
     messages = [{"role": "user", "content": "Who are you?", "message_id": "0"}]

--- a/libs/anaconda-assistant-sdk/tests/test_core.py
+++ b/libs/anaconda-assistant-sdk/tests/test_core.py
@@ -9,6 +9,7 @@ from pytest_mock import MockerFixture
 from requests.exceptions import StreamConsumedError
 import responses.matchers
 
+from anaconda_assistant import __version__ as version
 from anaconda_assistant.exceptions import (
     DailyQuotaExceeded,
     NotAcceptedTermsError,
@@ -197,6 +198,16 @@ def test_chat_client_system_message(mocked_api_client: APIClient) -> None:
         "role": "system",
         "content": system_message,
     }
+
+
+@pytest.mark.usefixtures("accepted_terms_and_data_collection")
+def test_chat_client_client_version(mocked_api_client: APIClient) -> None:
+    client = ChatClient(domain=mocked_api_client.config.domain)
+
+    messages = [{"role": "user", "content": "Who are you?", "message_id": "0"}]
+    res = client.completions(messages=messages)
+
+    assert res._response.request.headers["X-Client-Version"] == version
 
 
 @pytest.mark.usefixtures("accepted_terms_and_data_collection")


### PR DESCRIPTION
With the change from `https://assistant.anaconda.cloud` to `https://anaconda.com/api/assistant` the client implementation becomes much easier. There is no longer a need for a special assistant_domain config, it uses the domain config from anaconda-auth.

Here I also pass the correct version of the SDK in the headers and more carefully parse the response.