### PR TITLE
Fix config.toml issue in windows

### DIFF
--- a/libs/anaconda-assistant-conda/src/anaconda_assistant_conda/core.py
+++ b/libs/anaconda-assistant-conda/src/anaconda_assistant_conda/core.py
@@ -47,7 +47,7 @@ def set_config(table: str, key: str, value: Any) -> None:
     config_table[key] = value  # type: ignore
 
     config_toml.parent.mkdir(parents=True, exist_ok=True)
-    with open(config_toml, "w") as f:
+    with open(config_toml, "w", newline="\n") as f:
         tomlkit.dump(config, f)
 
 


### PR DESCRIPTION
File was getting saved with an extra newline added before each line

Notice LF changing to CRLF in the status bar in this video:
https://github.com/user-attachments/assets/70b0530c-c49a-4c1a-8be8-d1b49daba6f7

When a newline is added after `[plugin.assistant]`, the toml file can't be read because of a syntax error

This change fixes the issue by setting the newline char sequence to `\n`, which saves the file with the LF end line sequence