### PR TITLE
Fix config.toml issue in windows by changing tomlkit to tomli

### DIFF
--- a/libs/anaconda-assistant-conda/pyproject.toml
+++ b/libs/anaconda-assistant-conda/pyproject.toml
@@ -10,7 +10,8 @@ dependencies = [
   "rich",
   "requests",
   "pydantic >=2",
-  "tomlkit"
+  "tomli",
+  "tomli_w"
 ]
 description = "The Anaconda Assistant conda plugin"
 dynamic = ["version"]

--- a/libs/anaconda-assistant-conda/pyproject.toml
+++ b/libs/anaconda-assistant-conda/pyproject.toml
@@ -11,7 +11,7 @@ dependencies = [
   "requests",
   "pydantic >=2",
   "tomli",
-  "tomli_w"
+  "tomli-w"
 ]
 description = "The Anaconda Assistant conda plugin"
 dynamic = ["version"]

--- a/libs/anaconda-assistant-conda/src/anaconda_assistant_conda/core.py
+++ b/libs/anaconda-assistant-conda/src/anaconda_assistant_conda/core.py
@@ -47,7 +47,7 @@ def set_config(table: str, key: str, value: Any) -> None:
     config_table[key] = value  # type: ignore
 
     config_toml.parent.mkdir(parents=True, exist_ok=True)
-    with open(config_toml, "w") as f:
+    with open(config_toml, "w", newline="\n") as f:
         tomlkit.dump(config, f)
 
 

--- a/libs/anaconda-assistant-conda/src/anaconda_assistant_conda/core.py
+++ b/libs/anaconda-assistant-conda/src/anaconda_assistant_conda/core.py
@@ -8,7 +8,8 @@ from typing import Type
 from typing import Optional
 from unittest.mock import patch
 
-import tomlkit
+import tomli
+import tomli_w
 from anaconda_cli_base.config import anaconda_config_path
 from anaconda_cli_base.exceptions import register_error_handler
 from anaconda_cli_base.exceptions import ERROR_HANDLERS
@@ -31,24 +32,24 @@ def set_config(table: str, key: str, value: Any) -> None:
     if config_toml.exists():
         copy(config_toml, config_toml.with_suffix(".backup.toml"))
         with open(config_toml, "rb") as f:
-            config = tomlkit.load(f)
+            config = tomli.load(f)
     else:
-        config = tomlkit.document()
+        config = {}
 
     # Add table if it doesn't exist
     config_table = config
     for table_key in expanded:
-        if table_key not in config_table:  # type: ignore
-            config_table[table_key] = tomlkit.table()  # type: ignore
-        config_table = config_table[table_key]  # type: ignore
+        if table_key not in config_table:
+            config_table[table_key] = {}
+        config_table = config_table[table_key]
 
-    # config_table is still referenced in the config doc
-    # we can edit the value here and then write the whole doc back
-    config_table[key] = value  # type: ignore
+    # config_table is still referenced in the config dict
+    # we can edit the value here and then write the whole dict back
+    config_table[key] = value
 
     config_toml.parent.mkdir(parents=True, exist_ok=True)
-    with open(config_toml, "w", newline="\n") as f:
-        tomlkit.dump(config, f)
+    with open(config_toml, "wb") as f:
+        tomli_w.dump(config, f)
 
 
 @register_error_handler(UnspecifiedDataCollectionChoice)

--- a/libs/anaconda-assistant-conda/tests/test_core.py
+++ b/libs/anaconda-assistant-conda/tests/test_core.py
@@ -1,6 +1,6 @@
 from pathlib import Path
 
-import tomlkit
+import tomli
 from pytest import MonkeyPatch
 from anaconda_assistant_conda.core import set_config
 from anaconda_cli_base.config import anaconda_config_path
@@ -20,7 +20,7 @@ def test_set_config_missing_anaconda_directory(
     assert anaconda_config_path().exists()
 
     with config_toml.open("rb") as f:
-        data = tomlkit.load(f)
+        data = tomli.load(f)
         assert data["test_table"]["foo"] == "bar"  # type: ignore
 
 
@@ -39,7 +39,7 @@ def test_set_config_missing_anaconda_config_toml(
     assert anaconda_config_path().exists()
 
     with config_toml.open("rb") as f:
-        data = tomlkit.load(f)
+        data = tomli.load(f)
         assert data["test_table"]["foo"] == "bar"  # type: ignore
 
 
@@ -59,7 +59,7 @@ def test_set_config_empty_anaconda_config_toml(
     assert anaconda_config_path().exists()
 
     with config_toml.open("rb") as f:
-        data = tomlkit.load(f)
+        data = tomli.load(f)
         assert data["test_table"]["foo"] == "bar"  # type: ignore
 
 
@@ -71,7 +71,7 @@ def test_set_config_override_anaconda_config_toml(
     config_toml.write_text('[test_table]\nfoo = "baz"')
 
     with config_toml.open("rb") as f:
-        data = tomlkit.load(f)
+        data = tomli.load(f)
         assert data["test_table"]["foo"] == "baz"  # type: ignore
 
     monkeypatch.setenv("ANACONDA_CONFIG_TOML", str(config_toml))
@@ -83,5 +83,5 @@ def test_set_config_override_anaconda_config_toml(
     assert anaconda_config_path().exists()
 
     with config_toml.open("rb") as f:
-        data = tomlkit.load(f)
+        data = tomli.load(f)
         assert data["test_table"]["foo"] == "bar"  # type: ignore


### PR DESCRIPTION
tomli always converts line endings to LF, even if the file was originally CRLF