### PR TITLE
Fix extra space before [y/n]

### DIFF
--- a/libs/anaconda-assistant-conda/src/anaconda_assistant_conda/core.py
+++ b/libs/anaconda-assistant-conda/src/anaconda_assistant_conda/core.py
@@ -75,7 +75,7 @@ def data_collection_choice(e: Type[UnspecifiedDataCollectionChoice]) -> int:
 
         [bold green]Would you like to opt-in to data collection?[/bold green]
         """
-    )
+    ).rstrip()
     data_collection = Confirm.ask(msg)
     set_config("plugin.assistant", "data_collection", data_collection)
 

--- a/libs/anaconda-assistant-conda/src/anaconda_assistant_conda/prompt_accept_terms.py
+++ b/libs/anaconda-assistant-conda/src/anaconda_assistant_conda/prompt_accept_terms.py
@@ -12,7 +12,7 @@ def prompt_accept_terms() -> int:
           https://anaconda.com/legal
 
         [bold green]Are you more than 13 years old and accept the terms?[/bold green]"""
-    )
+    ).rstrip()
     accepted_terms = Confirm.ask(msg)
     set_config("plugin.assistant", "accepted_terms", accepted_terms)
     return accepted_terms


### PR DESCRIPTION
BEFORE:
<img width="614" alt="Screenshot 2025-06-02 at 12 34 42 PM" src="https://github.com/user-attachments/assets/ae5df29a-be43-4ea8-8bbd-3478873b6356" />

AFTER:
<img width="693" alt="Screenshot 2025-06-02 at 12 34 58 PM" src="https://github.com/user-attachments/assets/733fefb8-ff39-4b94-aca5-5adb004c8282" />

There's no obvious way to remove the extra space, so putting everything on a single line instead