### PR TITLE
Remove tool decorator params

### DIFF
--- a/libs/anaconda-assistant-mcp/src/anaconda_assistant_mcp/server.py
+++ b/libs/anaconda-assistant-mcp/src/anaconda_assistant_mcp/server.py
@@ -75,10 +75,7 @@ async def remove_environment(name: str) -> str:
     return f"Environment removal not implemented yet: {name}"
 
 
-@mcp.tool(
-    name="search_packages",
-    description="Search for available Conda packages matching a query string.",
-)
+@mcp.tool()
 async def search_packages(
     package_name: str, channel: Optional[str] = None, platform: Optional[str] = None
 ) -> list[str]:


### PR DESCRIPTION
We only need them if overriding docstring and func name